### PR TITLE
Logging

### DIFF
--- a/src/logger.h
+++ b/src/logger.h
@@ -30,7 +30,7 @@
 //
 #include <string>
 
-#define LOG(msg) Logger::get().log(msg, std::string(__FILE__), __LINE__)
+#define LOG(msg) Logger::get().log(msg, std::string(((strrchr(__FILE__, '/') ?: __FILE__ - 1) + 1)), __LINE__)
 
 class Logger
 {


### PR DESCRIPTION
Quick change to make the log macro output just the file name rather then the full path.

So the following:
/home/andrew/somepath/file.cpp

becomes:
file.cpp
