### PR TITLE
Help commands added

### DIFF
--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -67,21 +67,20 @@ Chat::Chat()
   registerStandardCommands();
 }
 
-void Chat::registerCommand(std::deque<std::string> words, std::string argumentString, std::string description, ChatCommand command, bool adminOnly)
+void Chat::registerCommand(Command *command)
 {
   // Loop thru all the words for this command
   std::string currentWord;
+  std::deque<std::string> words = command->names;
   while(!words.empty())
   {
     currentWord = words[0];
     words.pop_front();
 
-    if(adminOnly) {
+    if(command->adminOnly) {
       adminCommands[currentWord] = command;
-      adminCommandDescriptions[currentWord] = std::pair<std::string,std::string>(argumentString, description);
     } else {
       userCommands[currentWord] = command;
-      userCommandDescriptions[currentWord] = std::pair<std::string,std::string>(argumentString, description);
     }
   }
 }
@@ -298,9 +297,9 @@ bool Chat::handleMsg(User *user, std::string msg)
     // User commands
     CommandList::iterator iter;
     if((iter = userCommands.find(command)) != userCommands.end())
-      iter->second(user, command, cmd);
+      iter->second->callback(user, command, cmd);
     else if(user->admin && (iter = adminCommands.find(command)) != adminCommands.end())
-      iter->second(user, command, cmd);
+      iter->second->callback(user, command, cmd);
   }
   // Normal message
   else
@@ -362,43 +361,37 @@ bool Chat::sendMsg(User *user, std::string msg, MessageTarget action)
 
 void Chat::sendUserHelp(User* user, std::deque<std::string> args)
 {
-  if(args.size() == 0) {
-    for(CommandDescriptionList::iterator it = userCommandDescriptions.begin();
-        it != userCommandDescriptions.end();
-        it++) {
-      std::string args = it->second.first;
-      std::string description = it->second.second;
-      sendMsg(user, COLOR_BLUE + CHATCMDPREFIX + it->first + " " + args + " : " + COLOR_YELLOW + description, Chat::USER);
-    }
-  } else {
-    CommandDescriptionList::iterator iter;
-    if((iter = userCommandDescriptions.find(args.front())) != userCommandDescriptions.end()) {
-      std::string args = iter->second.first;
-      std::string description = iter->second.second;
-      sendMsg(user, COLOR_BLUE + CHATCMDPREFIX + iter->first + args, Chat::USER);
-      sendMsg(user, COLOR_YELLOW + CHATCMDPREFIX + description, Chat::USER);
-    } else {
-      sendMsg(user, COLOR_RED + "Unknown Command: " + args.front(), Chat::USER);
-    }
-  }
+  sendHelp(user, args, false);
 }
 
 void Chat::sendAdminHelp(User* user, std::deque<std::string> args)
 {
+  sendHelp(user, args, true);
+}
+
+void Chat::sendHelp(User *user, std::deque<std::string> args, bool adminOnly)
+{
+  CommandList *commandList = &userCommands;
+  std::string commandColor = COLOR_BLUE;
+  if(adminOnly) {
+    commandList = &adminCommands;
+    commandColor = COLOR_RED; // different color for admin commands
+  }
+
   if(args.size() == 0) {
-    for(CommandDescriptionList::iterator it = adminCommandDescriptions.begin();
-        it != adminCommandDescriptions.end();
+    for(CommandList::iterator it = commandList->begin();
+        it != commandList->end();
         it++) {
-      std::string args = it->second.first;
-      std::string description = it->second.second;
-      sendMsg(user, COLOR_RED + CHATCMDPREFIX + it->first + " " + args + " : " + COLOR_YELLOW + description, Chat::USER);
+      std::string args = it->second->arguments;
+      std::string description = it->second->description;
+      sendMsg(user, commandColor + CHATCMDPREFIX + it->first + " " + args + " : " + COLOR_YELLOW + description, Chat::USER);
     }
   } else {
-    CommandDescriptionList::iterator iter;
-    if((iter = adminCommandDescriptions.find(args.front())) != adminCommandDescriptions.end()) {
-      std::string args = iter->second.first;
-      std::string description = iter->second.second;
-      sendMsg(user, COLOR_RED + CHATCMDPREFIX + iter->first + args, Chat::USER);
+    CommandList::iterator iter;
+    if((iter = commandList->find(args.front())) != commandList->end()) {
+      std::string args = iter->second->arguments;
+      std::string description = iter->second->description;
+      sendMsg(user, commandColor + CHATCMDPREFIX + iter->first + args, Chat::USER);
       sendMsg(user, COLOR_YELLOW + CHATCMDPREFIX + description, Chat::USER);
     } else {
       sendMsg(user, COLOR_RED + "Unknown Command: " + args.front(), Chat::USER);

--- a/src/chat.h
+++ b/src/chat.h
@@ -38,7 +38,26 @@ public:
     OTHERS,
     ADMINS
   };
-  typedef void (*ChatCommand)(User *, std::string, std::deque<std::string> );
+  typedef void (*CommandCallback)(User *, std::string, std::deque<std::string> );
+
+  struct Command
+  {
+    std::deque<std::string> names;
+    std::string arguments;
+    std::string description;
+    CommandCallback callback;
+    bool adminOnly;
+
+    Command(std::deque<std::string> names, std::string arguments, std::string description, CommandCallback callback, bool adminOnly)
+    : names(names),
+      arguments(arguments),
+      description(description),
+      callback(callback),
+      adminOnly(adminOnly)
+    {
+    }
+  };
+
   //Chat();
   std::deque<std::string> admins;
   std::deque<std::string> banned;
@@ -50,9 +69,9 @@ public:
   bool loadBanned(std::string bannedFile);
   bool loadWhitelist(std::string whitelistFile);
   bool checkMotd(std::string motdFile);
-  void registerCommand(std::deque<std::string> words, std::string argumentString, std::string description, ChatCommand command, bool adminOnly);
-  void sendUserHelp(User* user, std::deque<std::string> args);
-  void sendAdminHelp(User* user, std::deque<std::string> args);
+  void registerCommand(Command *command);
+  void sendUserHelp(User *user, std::deque<std::string> args);
+  void sendAdminHelp(User *user, std::deque<std::string> args);
   static Chat* get()
   {
     if(!mChat) {
@@ -64,18 +83,15 @@ public:
 private:
   static Chat *mChat;
 
-  typedef std::map<std::string, ChatCommand> CommandList;
-  typedef std::pair<std::string, std::string> CommandArgsAndDescription;
-  typedef std::map<std::string, CommandArgsAndDescription> CommandDescriptionList;
+  typedef std::map<std::string, Command*> CommandList;
 
   CommandList userCommands;
   CommandList adminCommands;
-  CommandDescriptionList userCommandDescriptions;
-  CommandDescriptionList adminCommandDescriptions;
 
   Chat();
   void registerStandardCommands();
   std::deque<std::string> parseCmd(std::string cmd);
+  void sendHelp(User *user, std::deque<std::string> args, bool adminOnly);
 };
 
 #endif

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -637,32 +637,32 @@ void setHealth(User *user, std::string command, std::deque<std::string> args)
 
 void Chat::registerStandardCommands()
 {
-  // Players
-  registerCommand(parseCmd("about"), "", "Display server name & version", about, false);
-  registerCommand(parseCmd("home"), "", "Teleport to map spawn location", home, false);
-  registerCommand(parseCmd("kit"), "<name>", "Gives kit", kit, false);
-  registerCommand(parseCmd("motd"), "", "Display Message Of The Day", showMOTD, false);
-  registerCommand(parseCmd("players who"), "", "Lists online players", playerList, false);
-  registerCommand(parseCmd("rules"), "", "Display server rules", rules, false);
-  registerCommand(parseCmd("e em emote me"), "", "Emote", emote, false);
-  registerCommand(parseCmd("whisper w tell t"), "<player> <message>", "Send a private message", whisper, false);
-  registerCommand(parseCmd("dnd"), "", "Do Not Disturb - toggles receiving chat messages", doNotDisturb, false);
-  registerCommand(parseCmd("help"), "[<commandName>]", "Display this help message.", userHelp, false);
+  // // Players
+  registerCommand(new Command(parseCmd("about"), "", "Display server name & version", about, false));
+  registerCommand(new Command(parseCmd("home"), "", "Teleport to map spawn location", home, false));
+  registerCommand(new Command(parseCmd("kit"), "<name>", "Gives kit", kit, false));
+  registerCommand(new Command(parseCmd("motd"), "", "Display Message Of The Day", showMOTD, false));
+  registerCommand(new Command(parseCmd("players who"), "", "Lists online players", playerList, false));
+  registerCommand(new Command(parseCmd("rules"), "", "Display server rules", rules, false));
+  registerCommand(new Command(parseCmd("e em emote me"), "", "Emote", emote, false));
+  registerCommand(new Command(parseCmd("whisper w tell t"), "<player> <message>", "Send a private message", whisper, false));
+  registerCommand(new Command(parseCmd("dnd"), "", "Do Not Disturb - toggles receiving chat messages", doNotDisturb, false));
+  registerCommand(new Command(parseCmd("help"), "[<commandName>]", "Display this help message.", userHelp, false));
 
   // Admins Only
-  registerCommand(parseCmd("ban"), "<player>", "Bans (and kicks if online) <player> from server", ban, true);
-  registerCommand(parseCmd("ctp"), "<x> <y> <z>", "Teleport to coordinates (eg. /ctp 100 100 100)", coordinateTeleport, true);
-  registerCommand(parseCmd("give"), "<player> [count]", "Gives <player> [count] pieces of <id/alias>. By default [count] = 1", giveItems, true);
-  registerCommand(parseCmd("gps"), "[<player>]", "Show own coordinates or show <player>'s coordinates", showPosition, true);
-  registerCommand(parseCmd("kick"), "<player>", "Kicks a player with optional kick message", kick, true);
-  registerCommand(parseCmd("mute"), "<player>", "Mutes a player with optional message", mute, true);
-  registerCommand(parseCmd("regen"), "", "Regenerates lightning", regenerateLighting, true);
-  registerCommand(parseCmd("reload"), "", "Reload admins and configuration", reloadConfiguration, true);
-  registerCommand(parseCmd("save"), "", "Manually save map to disc", saveMap, true);
-  registerCommand(parseCmd("sethealth"), "<player>", "Set a player's health. <health> = 0-20", setHealth, true);
-  registerCommand(parseCmd("settime"), "<time>", "Sets server time. (<time> = 0-24000, 0 & 24000 = day, ~15000 = night)", setTime, true);
-  registerCommand(parseCmd("tp"), "<player> [<anotherPlayer>]", "Teleport yourself to <player>'s position or <player> to <anotherPlayer>", userTeleport, true);
-  registerCommand(parseCmd("unban"), "<player>", "Lift a ban of a player", unban, true);
-  registerCommand(parseCmd("unmute"), "<player>", "Unmutes a given player", unmute, true);
-  registerCommand(parseCmd("adminhelp"), "[<commandName>]", "Displays help messages for admin commands.", adminHelp, true);
+  registerCommand(new Command(parseCmd("ban"), "<player>", "Bans (and kicks if online) <player> from server", ban, true));
+  registerCommand(new Command(parseCmd("ctp"), "<x> <y> <z>", "Teleport to coordinates (eg. /ctp 100 100 100)", coordinateTeleport, true));
+  registerCommand(new Command(parseCmd("give"), "<player> [count]", "Gives <player> [count] pieces of <id/alias>. By default [count] = 1", giveItems, true));
+  registerCommand(new Command(parseCmd("gps"), "[<player>]", "Show own coordinates or show <player>'s coordinates", showPosition, true));
+  registerCommand(new Command(parseCmd("kick"), "<player>", "Kicks a player with optional kick message", kick, true));
+  registerCommand(new Command(parseCmd("mute"), "<player>", "Mutes a player with optional message", mute, true));
+  registerCommand(new Command(parseCmd("regen"), "", "Regenerates lightning", regenerateLighting, true));
+  registerCommand(new Command(parseCmd("reload"), "", "Reload admins and configuration", reloadConfiguration, true));
+  registerCommand(new Command(parseCmd("save"), "", "Manually save map to disc", saveMap, true));
+  registerCommand(new Command(parseCmd("sethealth"), "<player>", "Set a player's health. <health> = 0-20", setHealth, true));
+  registerCommand(new Command(parseCmd("settime"), "<time>", "Sets server time. (<time> = 0-24000, 0 & 24000 = day, ~15000 = night)", setTime, true));
+  registerCommand(new Command(parseCmd("tp"), "<player> [<anotherPlayer>]", "Teleport yourself to <player>'s position or <player> to <anotherPlayer>", userTeleport, true));
+  registerCommand(new Command(parseCmd("unban"), "<player>", "Lift a ban of a player", unban, true));
+  registerCommand(new Command(parseCmd("unmute"), "<player>", "Unmutes a given player", unmute, true));
+  registerCommand(new Command(parseCmd("adminhelp"), "[<commandName>]", "Displays help messages for admin commands.", adminHelp, true));
 }


### PR DESCRIPTION
I added two new commands to the chat:
    /help [<cmdname>]
and 
    /adminhelp [<cmdname>]

The first one displays help text for user commands, the second one for admin commands. Both take either 0 or 1 argument. If an argument is given, it interprets it as a command name and only displays the help text for that command, otherwise (no arg given) simply displays help text for all commands.
Admin help displays command names in red, for visual distinction from user commands.  
