### PR TITLE
Data type bug due to addition in "set slot" packet when placing blocks

### DIFF
--- a/src/packets.cpp
+++ b/src/packets.cpp
@@ -671,7 +671,7 @@ int PacketHandler::player_block_placement(User *user)
       //ToDo: add holding change packet.
     }
     user->buffer << (sint8)PACKET_SET_SLOT << (sint8)WINDOW_PLAYER 
-                 << (sint16)INV_TASKBAR_START+user->currentItemSlot() 
+                 << (sint16)(INV_TASKBAR_START+user->currentItemSlot())
                  << (sint16)user->inv[INV_TASKBAR_START+user->currentItemSlot()].type;
     if(user->inv[INV_TASKBAR_START+user->currentItemSlot()].type != -1)
     {


### PR DESCRIPTION
Ought there not be a way to send packets other than hardcoding the packets in every place they are sent, to avoid this sort of thing? :)
