### PR TITLE
Create recipe/plugin directories fix

### DIFF
--- a/src/mineserver.cpp
+++ b/src/mineserver.cpp
@@ -225,9 +225,6 @@ int main(int argc, char* argv[])
   }
   std::cout << "Configuration directory is \"" << Mineserver::get()->config()->config_path << "\"." << std::endl;
 
-  // create home and copy files if necessary
-  Mineserver::get()->configDirectoryPrepare(Mineserver::get()->config()->config_path);
-
   // load config
   Config & config = *Mineserver::get()->config();
   if (!config.load(cfg))
@@ -236,6 +233,9 @@ int main(int argc, char* argv[])
   }
 
   LOG2(INFO, "Using config: " + cfg);
+  
+  // create home and copy files if necessary
+  Mineserver::get()->configDirectoryPrepare(Mineserver::get()->config()->config_path);
 
   if (overrides.size())
   {
@@ -835,17 +835,7 @@ bool Mineserver::configDirectoryPrepare(const std::string& path)
   std::cout << std::endl
             << "configDirectoryPrepare(): target directory = \"" << path
             << "\", distribution source is \"" << distsrc << "\"." << std::endl
-            << "WARNING: This function is not implemented fully at present." << std::endl
-            << "You must check that all the necessary files are in the target directory" << std::endl
-            << "(including recipes and plugins) and that the config file is correct." << std::endl
             << std::endl;
-
-  /*
-     WARNING:
-     ========
-     kiki64's commit sort've messed things up. Someone needs to re-enable config.cfg's values for
-     target paths (home, plugins, and files paths). I have fixed the issue with windows vs. *nix.
-  */
 
   struct stat st;
   //Create Mineserver directory
@@ -860,23 +850,22 @@ bool Mineserver::configDirectoryPrepare(const std::string& path)
   }
 
   //Create recipe/plugin directories
-  // TODO: Fill in respective values with config()->sData("system.path.data")) and "system.path.plugins"
   const std::string directories [] = 
   {
-    "plugins",
-    "files",
-    "files\\recipes",
-    "files\\recipes\\armour",
-    "files\\recipes\\block",
-    "files\\recipes\\cloth",
-    "files\\recipes\\dyes",
-    "files\\recipes\\food",
-    "files\\recipes\\materials",
-    "files\\recipes\\mechanism",
-    "files\\recipes\\misc",
-    "files\\recipes\\tools",
-    "files\\recipes\\transport",
-    "files\\recipes\\weapons",
+    config()->sData("system.path.plugins"),
+    config()->sData("system.path.data"),
+    directories[1] + PATH_SEPARATOR + "recipes",
+    directories[2] + PATH_SEPARATOR + "armour",
+    directories[2] + PATH_SEPARATOR + "block",
+    directories[2] + PATH_SEPARATOR + "cloth",
+    directories[2] + PATH_SEPARATOR + "dyes",
+    directories[2] + PATH_SEPARATOR + "food",
+    directories[2] + PATH_SEPARATOR + "materials",
+    directories[2] + PATH_SEPARATOR + "mechanism",
+    directories[2] + PATH_SEPARATOR + "misc",
+    directories[2] + PATH_SEPARATOR + "tools",
+    directories[2] + PATH_SEPARATOR + "transport",
+    directories[2] + PATH_SEPARATOR + "weapons"
   };
   for (size_t i = 0; i < sizeof(directories) / sizeof(directories[0]); i++)
   {


### PR DESCRIPTION
Plugins and recipe paths now use config.cfg's values when creating directories (if not exists) and unix path fix.
