### PR TITLE
Create recipe/plugin directories fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,9 +237,10 @@ FOREACH(path ${mineserver_configs} ${mineserver_recipes})
 ENDFOREACH()
 
 # In the Debug build, we provide a local config file.
-IF(CMAKE_BUILD_TYPE MATCHES Debug)
+#IF(CMAKE_BUILD_TYPE MATCHES Debug)
     CONFIGURE_FILE(files/config.cfg "${EXECUTABLE_OUTPUT_PATH}/config.cfg" COPYONLY)
-ENDIF()
+    CONFIGURE_FILE(files/item_alias.cfg "${EXECUTABLE_OUTPUT_PATH}/item_alias.cfg" COPYONLY)
+#ENDIF()
 
 
 

--- a/src/mineserver.cpp
+++ b/src/mineserver.cpp
@@ -224,7 +224,7 @@ int main(int argc, char* argv[])
 #endif
   }
   std::cout << "Configuration directory is \"" << Mineserver::get()->config()->config_path << "\"." << std::endl;
-
+  
   // load config
   Config & config = *Mineserver::get()->config();
   if (!config.load(cfg))
@@ -234,9 +234,6 @@ int main(int argc, char* argv[])
 
   LOG2(INFO, "Using config: " + cfg);
   
-  // create home and copy files if necessary
-  Mineserver::get()->configDirectoryPrepare(Mineserver::get()->config()->config_path);
-
   if (overrides.size())
   {
     std::stringstream override_config;
@@ -252,9 +249,12 @@ int main(int argc, char* argv[])
       return EXIT_FAILURE;
     }
   }
+  
+  // create home and copy files if necessary
+  Mineserver::get()->configDirectoryPrepare(Mineserver::get()->config()->config_path);
 
   bool ret = Mineserver::get()->init();
-
+  
   if (!ret)
   {
     LOG2(ERROR, "Failed to start Mineserver!");
@@ -917,18 +917,18 @@ bool Mineserver::configDirectoryPrepare(const std::string& path)
 
     if(temp[i].substr(temp[i].size() - 7).compare(".recipe") == 0)//If a recipe file
     {
-      namein  = pathOfExecutable() + PATH_SEPARATOR + "files" + PATH_SEPARATOR + "recipes" + PATH_SEPARATOR + temp[i];
-      nameout = path + PATH_SEPARATOR + "files" + PATH_SEPARATOR + "recipes" + PATH_SEPARATOR + temp[i];
+      namein  = pathOfExecutable() + PATH_SEPARATOR + directories[2] + PATH_SEPARATOR + temp[i];
+      nameout = path + PATH_SEPARATOR + directories[2] + PATH_SEPARATOR + temp[i];
     }
     else if ((temp[i].substr(temp[i].size() - 4).compare(".dll") == 0) ||
              (temp[i].substr(temp[i].size() - 3).compare(".so") == 0))
     {
-      namein  = pathOfExecutable() + PATH_SEPARATOR + "files" + PATH_SEPARATOR + "plugins" + PATH_SEPARATOR + temp[i];
-      nameout = path + PATH_SEPARATOR + "plugins" + PATH_SEPARATOR + temp[i];
+      namein  = pathOfExecutable() + PATH_SEPARATOR + directories[1] + PATH_SEPARATOR + directories[0] + PATH_SEPARATOR + temp[i];
+      nameout = path + PATH_SEPARATOR + directories[1] + PATH_SEPARATOR + temp[i];
     }
     else
     {
-      namein  = pathOfExecutable() + PATH_SEPARATOR + "files" + PATH_SEPARATOR + temp[i];
+      namein  = pathOfExecutable() + PATH_SEPARATOR + directories[1] + PATH_SEPARATOR + temp[i];
       nameout = path + PATH_SEPARATOR + temp[i];
     }
 


### PR DESCRIPTION
Plugins and recipe paths now use config.cfg's values when creating directories (if not exists) and unix path fix.
