### PR TITLE
Fixes in the UTF-8 code

### DIFF
--- a/src/utf8.h
+++ b/src/utf8.h
@@ -79,7 +79,7 @@ inline unsigned int getOneCodepointFromUTF8(const std::string& str, size_t & pos
     return data[0];
   }
 
-  else if ((data[0] & 0xE0) == 0xC0) // first byte: 110xxxxxx
+  else if ((data[0] & 0xE0) == 0xC0) // first byte: 110xxxxx
   {
     // 2 code units
 
@@ -110,7 +110,6 @@ inline unsigned int getOneCodepointFromUTF8(const std::string& str, size_t & pos
       position = str.length();
       return -1;
     }
-
     return ((data[0] & 0x0F) << 12) | ((data[1] & 0x3F) << 6) | (data[2] & 0x3F);
   }
 


### PR DESCRIPTION
Hi there!

I was going to implement the active players / max players statistics for the multiplayer server connect screen and stumbled upon some issues with the UTF-8 code in `src/utf8.h`. Specifically, some of the bitmasks used seemed to be a little off, resulting in a malformed UTF-16 sequence sent to the server.

For example, for a 2-byte codepoint, the first byte [has to be](http://en.wikipedia.org/wiki/UTF-8#Description) `110xxxxx`, so the first three bits have to be `110`. The bitmask to check this has to be `11100000`, and a bitwise-and operation must have the result `11000000` (because only the first two bits are set, the third is unset). Thus, the correct check has to be `(data[0] & 0xE0) == 0xC0`.

Similarly, the code to check the subsequent bytes (which have to be `10xxxxxx`) is `(byte & 0xC0) == 0x80`.

I have done some checks with that code. Most of them succeeded, but then I ran into issues with non-BMP characters that I don't fully understand :D But from a theoretical point of view, this code should be correct. Please review, all these bits and bytes make my brain hurt a little bit.

Cheers!

Friedrich
