### PR TITLE
Added "head yaw" byte to the Spawn Mob packet. Fixes passiveMob plugin.

### DIFF
--- a/src/mob.cpp
+++ b/src/mob.cpp
@@ -38,6 +38,7 @@ Mob::Mob()
   z(0),
   map(0),
   yaw(0),
+  head_yaw(0), // TODO: actually use head_yaw
   pitch(0),
   spawned(false),
   respawnable(false),

--- a/src/mob.h
+++ b/src/mob.h
@@ -54,7 +54,7 @@ public:
   int8_t type;
   double x, y, z;
   size_t map;
-  int8_t yaw, pitch;
+  int8_t yaw, pitch, head_yaw;
   MetaData metadata;
   bool spawned;
   bool respawnable;

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -66,19 +66,19 @@ class Protocol
       return ret;
     }
 
-    static Packet mobSpawn(int eid, int8_t type, double x, double y, double z, int yaw, int pitch, MetaData& metadata)
+    static Packet mobSpawn(int eid, int8_t type, double x, double y, double z, int yaw, int pitch, int head_yaw, MetaData& metadata)
     {
       // Warning! This converts absolute double coordinates to absolute integer coordinates!
       Packet ret;
       ret << (int8_t)PACKET_MOB_SPAWN << (int32_t)eid << (int8_t)type
           << (int32_t)(x * 32) << (int32_t)(y * 32) << (int32_t)(z * 32)
-          << (int8_t)yaw << (int8_t)pitch << metadata;
+          << (int8_t)yaw << (int8_t)pitch << (int8_t)head_yaw << metadata;
       return ret;
     }
 
     static Packet mobSpawn(Mob& mob)
     {
-      return Protocol::mobSpawn(mob.UID, mob.type, mob.x, mob.y, mob.z, mob.yaw, mob.pitch, mob.metadata);
+      return Protocol::mobSpawn(mob.UID, mob.type, mob.x, mob.y, mob.z, mob.yaw, mob.pitch, mob.head_yaw, mob.metadata);
     }
 
     static Packet destroyEntity(int eid)


### PR DESCRIPTION
With the `passiveMobs` plugin enabled, the client died quickly after connecting to the server with a message like this: 

```
java.io.IOException: Received string length longer than maximum allowed (7111 > 64)
    at abs.a(SourceFile:197)
    at aim.a(SourceFile:226)
    at aay.a(SourceFile:45)
    at abs.a(SourceFile:155)
    at lg.e(SourceFile:189)
    at lg.c(SourceFile:9)
    at rl.run(SourceFile:76)
```

This happened because the Spawn Mob packet (server->client) lacked the "head yaw" byte ([see here](http://wiki.vg/Protocol#Spawn_Mob_.280x18.29), though I don't know for how long it has been around). This commit adds the byte to the packet. It's more a quickfix though because the head yaw isn't used in the server code, so I added a TODO.
