### PR TITLE
Fixed bug where certain UCS-2 codepoints were not decoded correctly

### DIFF
--- a/src/packets.cpp
+++ b/src/packets.cpp
@@ -1534,7 +1534,7 @@ Packet& Packet::operator>>(std::string& str)
 
     if (lenval && haveData(2 * lenval)) // We ASSUME that every character takes 2 bytes. DANGEROUS.
     {
-      char buf[2];
+      unsigned char buf[2];
       t_codepoint ccp;
 
       for (size_t i = 0;  i < lenval; ++i)


### PR DESCRIPTION
This fixes the usage of certain characters in the chat, e.g. "ö", and it happened because there was a `char` that needed to be an `unsigned char`.
ö is the [Unicode codepoint 246](http://www.carrickfergus.de/public/unicode.php?action=by_cpnthex&cpnthex=f6). In UCS-2, it is represented by the sequence `0x00 0xf6` (big endian). Without the change, the second byte is treated as a negative number, which gets really big when casted to `unsigned int`. Sounds fun, but I can't really explain it. :D
