### PR TITLE
Exceptions in Map destructor

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -110,9 +110,14 @@ Map::~Map()
   // louisdx: This destructor is doing WAY too much. All this should be in a separate function.
   // A destructor must never throw, and this destructor does tons of non-exception-safe stuff.
 
-  for (ChunkMap::const_iterator it = chunks.begin(); it != chunks.end(); )
+  // jim: error with the comparison it != chunks.end(), go by mapsize instead
+  // releaseMap frees the iterator, so use prev
+  ChunkMap::const_iterator it = chunks.begin();
+  ChunkMap::const_iterator prev;
+  while (chunks.size() != 0)
   {
-    releaseMap((it++)->first);
+   prev = it++;
+	releaseMap(prev->first);
   }
 
   // Free item memory

--- a/src/mineserver.cpp
+++ b/src/mineserver.cpp
@@ -207,8 +207,13 @@ Mineserver::Mineserver(int args, char **argarray)
       break;
     }
   }
-  
+
+// VS2012 debug wouldn't be able to find config file without this
+#ifdef DEBUG
+  const std::string path_exe = "../bin/";
+#else
   const std::string path_exe = "./";
+#endif
   
   // If config file is provided as an argument
   if (!cfg.empty())


### PR DESCRIPTION
Iterator comparisons in the ChunkMap caused exceptions to be thrown; changed iteration to go by map.size(). Done in VS2012
