### PR TITLE
Fixed Mac Compiling Problems

### DIFF
--- a/include/chunkmap.h
+++ b/include/chunkmap.h
@@ -34,8 +34,14 @@
 #include <ctime>
 
 #include "tr1.h"
-#include TR1INCLUDE(unordered_map)
+
+#ifdef __APPLE__
+#include <tr1/memory>
+#include <tr1/unordered_map>
+#else
 #include TR1INCLUDE(memory)
+#include TR1INCLUDE(unordered_map)
+#endif
 
 #include "packets.h"
 #include "user.h"

--- a/include/constants.h
+++ b/include/constants.h
@@ -34,7 +34,11 @@
 #include <iostream>
 
 #include "tr1.h"
+#ifdef __APPLE__
+#include <tr1/memory>
+#else
 #include TR1INCLUDE(memory)
+#endif
 
 // configuration from build system
 #include "configure.h"

--- a/include/inventory.h
+++ b/include/inventory.h
@@ -32,7 +32,11 @@
 #include <vector>
 
 #include "tr1.h"
+#ifdef __APPLE__
+#include <tr1/memory>
+#else
 #include TR1INCLUDE(memory)
+#endif
 
 class User;
 

--- a/include/metadata.h
+++ b/include/metadata.h
@@ -31,7 +31,11 @@
 #include <vector>
 #include "packets.h"
 #include "tr1.h"
+#ifdef __APPLE__
+#include <tr1/memory>
+#else
 #include TR1INCLUDE(memory)
+#endif
 
 class MetaDataElem
 {

--- a/include/mineserver.h
+++ b/include/mineserver.h
@@ -33,8 +33,12 @@
 #include <string>
 
 #include "tr1.h"
-#include TR1INCLUDE(memory)
 
+#ifdef __APPLE__
+#include <tr1/memory>
+#else
+#include TR1INCLUDE(memory)
+#endif
 
 //Enable protocol encryption
 #define PROTOCOL_ENCRYPTION
@@ -242,7 +246,9 @@ public:
   // Set a pointer to the inventory
   inline void setInventory(Inventory* inventory)
   {
-    m_inventory = m_inventory;
+    m_inventory = inventory;
+      // was m_inventory = m_inventory before,
+      // which seems redundant. -- gk
   }
 
 private:

--- a/include/plugin.h
+++ b/include/plugin.h
@@ -34,8 +34,14 @@
 #include <list>
 
 #include "tr1.h"
+
+#ifdef __APPLE__
+#include <tr1/memory>
+#include <tr1/unordered_map>
+#else
 #include TR1INCLUDE(memory)
 #include TR1INCLUDE(unordered_map)
+#endif
 
 //Fix Winsock2 error that occurs when Windows.h is included before it.
 #define _WINSOCKAPI_

--- a/include/random.h
+++ b/include/random.h
@@ -32,7 +32,11 @@
 #include <stdint.h>
 
 #include "tr1.h"
+#ifdef __APPLE__
+#include <tr1/random>
+#else
 #include TR1INCLUDE(random)
+#endif
 
 
 // This is our core PRNG engine. The Mersenne Twister is both fast and good.

--- a/include/tree.h
+++ b/include/tree.h
@@ -31,8 +31,13 @@
 #include <stack>
 
 #include "tr1.h"
+#ifdef __APPLE__
+#include <tr1/memory>
+#include <tr1/array>
+#else
 #include TR1INCLUDE(memory)
 #include TR1INCLUDE(array)
+#endif
 
 #include "constants.h"
 #include "mineserver.h"

--- a/plugins/commands/commands.cpp
+++ b/plugins/commands/commands.cpp
@@ -35,8 +35,13 @@
 #include <ctime>
 
 #include "tr1.h"
-#include TR1INCLUDE(unordered_map)
+#ifdef __APPLE__
+#include <tr1/memory>
+#include <tr1/unordered_map>
+#else
 #include TR1INCLUDE(memory)
+#include TR1INCLUDE(unordered_map)
+#endif
 
 #define MINESERVER_C_API
 #include "plugin_api.h"

--- a/plugins/passiveMobs/passiveMobs.cpp
+++ b/plugins/passiveMobs/passiveMobs.cpp
@@ -38,7 +38,11 @@
 #include <cmath>
 
 #include "tr1.h"
+#ifdef __APPLE__
+#include <tr1/memory>
+#else
 #include TR1INCLUDE(memory)
+#endif
 
 
 #define MINESERVER_C_API

--- a/src/config/lexer.h
+++ b/src/config/lexer.h
@@ -33,7 +33,11 @@
 #include <utility>
 
 #include "tr1.h"
+#ifdef __APPLE__
+#include <tr1/memory>
+#else
 #include TR1INCLUDE(memory)
+#endif
 
 enum {
   CONFIG_TOKEN_ENTITY = 1,

--- a/src/config/node.h
+++ b/src/config/node.h
@@ -33,7 +33,11 @@
 #include <list>
 
 #include "tr1.h"
+#ifdef __APPLE__
+#include <tr1/memory>
+#else
 #include TR1INCLUDE(memory)
+#endif
 
 #include <stdint.h>
 

--- a/src/config/parser.h
+++ b/src/config/parser.h
@@ -32,7 +32,11 @@
 #include <stdint.h>
 
 #include "tr1.h"
+#ifdef __APPLE__
+#include <tr1/memory>
+#else
 #include TR1INCLUDE(memory)
+#endif
 
 enum
 {

--- a/src/mcregion.cpp
+++ b/src/mcregion.cpp
@@ -58,6 +58,10 @@ struct RegionFile {
 #include <dirent.h>
 #endif
 
+#ifdef __APPLE__
+#include <dirent.h>
+#endif
+
 #include "mcregion.h"
 #include "constants.h"
 #include "logger.h"

--- a/src/sockets.cpp
+++ b/src/sockets.cpp
@@ -39,7 +39,11 @@ typedef int socklen_t;
 #include <algorithm>
 
 #include "tr1.h"
+#ifdef __APPLE__
+#include <tr1/array>
+#else
 #include TR1INCLUDE(array)
+#endif
 
 #include "sockets.h"
 #include "tools.h"

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -32,6 +32,19 @@
 #include <climits>
 #endif
 
+#ifdef __APPLE__
+#include <unistd.h>
+#include <libgen.h>
+#include <wordexp.h>
+#include <sys/stat.h>
+#include <climits>
+
+// Mac workaround because lack of clock_gettime
+// (idk why. But its a common problem.)
+#include <mach/clock.h>
+#include <mach/mach.h>
+#endif
+
 #ifdef _WIN32
 #include <direct.h>
 #define _WINSOCKAPI_ //Stops windows.h from including winsock.h
@@ -386,9 +399,19 @@ std::pair<std::string, std::string> pathOfFile(const std::string& filename)
 uint64_t microTime()
 {
 #ifndef WIN32
+  #ifdef __APPLE__
+  // copied from gist.github.com/jbenet/1087739
+  clock_serv_t cclock;
+  mach_timespec_t m_ts;
+  host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
+  clock_get_time(cclock, &m_ts);
+  mach_port_deallocate(mach_task_self(), cclock);
+  return (m_ts.tv_sec*(uint64_t)1000000 + m_ts.tv_nsec/(uint64_t)1000);
+  #else
   struct timespec now;
   clock_gettime(CLOCK_MONOTONIC, &now);
   return (now.tv_sec*(uint64_t)1000000 + now.tv_nsec/(uint64_t)1000);
+  #endif
 #else
   FILETIME ft;
   GetSystemTimeAsFileTime(&ft);


### PR DESCRIPTION
Because TR1 couldn't be included by TR1INCLUDE(*).
Catched now with #ifdef everywhere TR1 gets included.
Compiles now without an error here. :) (just some warnings which were
there before).
Also includes a workaround for clock_gettime(); which is not supported on OSX.
