### PR TITLE
Fix build error

### DIFF
--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -42,9 +42,9 @@ Packet Protocol::encryptionRequest()
 {
   Packet ret;
   ret << MS_VarInt((uint32_t)PACKET_OUT_ENCRYPTION_REQUEST) << ServerInstance->serverID 
-  << MS_VarInt(ServerInstance->publicKey.size());
+  << MS_VarInt((int64_t)ServerInstance->publicKey.size());
   ret.addToWrite((uint8_t*)ServerInstance->publicKey.c_str(),ServerInstance->publicKey.size());
-  ret << MS_VarInt(ServerInstance->encryptionBytes.size());
+  ret << MS_VarInt((int64_t)ServerInstance->encryptionBytes.size());
   ret.addToWrite((uint8_t*)ServerInstance->encryptionBytes.c_str(),ServerInstance->encryptionBytes.size());
   return ret;
 }


### PR DESCRIPTION
On Debian, buid fails with `error: call of overloaded 'VarInt_internal(std::basic_string<char>::size_type)' is ambiguous`. This patch fixes it.

But the client (1.8.9) fails to connect to the server with error `Internal Exception: io.netty.handler.codec.DecoderException: java.io.IOException: Bad packet id 66` (the id varies) or timeout. Probably another bug.